### PR TITLE
i2c

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 #![doc = include_str!("../README.md")]
 
 use configuration::Configuration;
+use constants::DEFAULT_I2C_ADDRESS;
 use embedded_hal::blocking::delay::DelayMs;
 use embedded_hal::blocking::i2c;
 use error::Error;
@@ -30,225 +31,168 @@ mod test_writing;
 
 /// As5600 driver instance.
 #[derive(Debug, PartialEq)]
-pub struct As5600 {
+pub struct As5600<I2C> {
     address: u8,
+    bus: I2C,
 }
 
-impl As5600 {
+impl<E, I2C: i2c::Read<Error = E> + i2c::Write<Error = E> + i2c::WriteRead<Error = E>> As5600<I2C> {
     /// Create a new As5600 driver instance.
-    pub fn new(address: u8) -> Self {
-        Self { address }
+    pub fn new(bus: I2C) -> Self {
+        Self::with_address(DEFAULT_I2C_ADDRESS, bus)
+    }
+
+    /// Create a new As5600 driver instance.
+    pub fn with_address(address: u8, bus: I2C) -> Self {
+        Self { address, bus }
     }
 
     /// Get value of register `RAW_ANGLE`.
-    pub fn raw_angle<I2c, E>(&mut self, i2c: &mut I2c) -> Result<u16, Error<E>>
-    where
-        I2c: i2c::Read<Error = E> + i2c::Write<Error = E> + i2c::WriteRead<Error = E>,
-    {
+    pub fn raw_angle(&mut self) -> Result<u16, Error<E>> {
         // 12-bit value.
-        Ok(self.read_u16(Register::RawAngle, i2c)? & 0x0FFF)
+        Ok(self.read_u16(Register::RawAngle)? & 0x0FFF)
     }
 
     /// Get value of register `ANGLE`.
-    pub fn angle<I2c, E>(&mut self, i2c: &mut I2c) -> Result<u16, Error<E>>
-    where
-        I2c: i2c::Read<Error = E> + i2c::Write<Error = E> + i2c::WriteRead<Error = E>,
-    {
+    pub fn angle(&mut self) -> Result<u16, Error<E>> {
         // 12-bit value.
-        Ok(self.read_u16(Register::Angle, i2c)? & 0x0FFF)
+        Ok(self.read_u16(Register::Angle)? & 0x0FFF)
     }
 
     /// Get value of register `ZMCO`.
-    pub fn zmco<I2c, E>(&mut self, i2c: &mut I2c) -> Result<u8, Error<E>>
-    where
-        I2c: i2c::Read<Error = E> + i2c::Write<Error = E> + i2c::WriteRead<Error = E>,
-    {
+    pub fn zmco(&mut self) -> Result<u8, Error<E>> {
         let mut buffer = [0u8; 1];
-        i2c.write_read(self.address, &[Register::Zmco.into()], &mut buffer)?;
+        self.bus
+            .write_read(self.address, &[Register::Zmco.into()], &mut buffer)?;
         Ok(buffer[0] & 0b0000_0011)
     }
 
     /// Get value of register `STATUS`.
-    pub fn magnet_status<I2c, E>(&mut self, i2c: &mut I2c) -> Result<status::Status, Error<E>>
-    where
-        I2c: i2c::Read<Error = E> + i2c::Write<Error = E> + i2c::WriteRead<Error = E>,
-    {
+    pub fn magnet_status(&mut self) -> Result<status::Status, Error<E>> {
         let mut buffer = [0u8; 1];
-        i2c.write_read(self.address, &[Register::Status.into()], &mut buffer)?;
+        self.bus
+            .write_read(self.address, &[Register::Status.into()], &mut buffer)?;
         status::Status::try_from(buffer).map_err(Error::Status)
     }
 
     /// Get value of register `ZPOS`.
-    pub fn zero_position<I2c, E>(&mut self, i2c: &mut I2c) -> Result<u16, Error<E>>
-    where
-        I2c: i2c::Read<Error = E> + i2c::Write<Error = E> + i2c::WriteRead<Error = E>,
-    {
+    pub fn zero_position(&mut self) -> Result<u16, Error<E>> {
         // 12-bit value.
-        Ok(self.read_u16(Register::Zpos, i2c)? & 0x0FFF)
+        Ok(self.read_u16(Register::Zpos)? & 0x0FFF)
     }
 
     /// Set value of register `ZPOS`.
-    pub fn set_zero_position<I2c, E>(&mut self, bytes: u16, i2c: &mut I2c) -> Result<(), Error<E>>
-    where
-        I2c: i2c::Read<Error = E> + i2c::Write<Error = E> + i2c::WriteRead<Error = E>,
-    {
+    pub fn set_zero_position(&mut self, bytes: u16) -> Result<(), Error<E>> {
         // 12-bit value.
-        self.write_u16(Register::Zpos, bytes & 0x0FFF, i2c)
+        self.write_u16(Register::Zpos, bytes & 0x0FFF)
     }
 
     /// Get value of register `MPOS`.
-    pub fn maximum_position<I2c, E>(&mut self, i2c: &mut I2c) -> Result<u16, Error<E>>
-    where
-        I2c: i2c::Read<Error = E> + i2c::Write<Error = E> + i2c::WriteRead<Error = E>,
-    {
+    pub fn maximum_position(&mut self) -> Result<u16, Error<E>> {
         // 12-bit value.
-        Ok(self.read_u16(Register::Mpos, i2c)? & 0x0FFF)
+        Ok(self.read_u16(Register::Mpos)? & 0x0FFF)
     }
 
     /// Set value of register `MPOS`.
-    pub fn set_maximum_position<I2c, E>(
-        &mut self,
-        bytes: u16,
-        i2c: &mut I2c,
-    ) -> Result<(), Error<E>>
-    where
-        I2c: i2c::Read<Error = E> + i2c::Write<Error = E> + i2c::WriteRead<Error = E>,
-    {
+    pub fn set_maximum_position(&mut self, bytes: u16) -> Result<(), Error<E>> {
         // 12-bit value.
-        self.write_u16(Register::Mpos, bytes & 0x0FFF, i2c)
+        self.write_u16(Register::Mpos, bytes & 0x0FFF)
     }
 
     /// Get value of register `MANG`.
-    pub fn maximum_angle<I2c, E>(&mut self, i2c: &mut I2c) -> Result<u16, Error<E>>
-    where
-        I2c: i2c::Read<Error = E> + i2c::Write<Error = E> + i2c::WriteRead<Error = E>,
-    {
+    pub fn maximum_angle(&mut self) -> Result<u16, Error<E>> {
         // 12-bit value.
-        Ok(self.read_u16(Register::Mang, i2c)? & 0x0FFF)
+        Ok(self.read_u16(Register::Mang)? & 0x0FFF)
     }
 
     /// Set value of register `MANG`.
-    pub fn set_maximum_angle<I2c, E>(&mut self, bytes: u16, i2c: &mut I2c) -> Result<(), Error<E>>
-    where
-        I2c: i2c::Read<Error = E> + i2c::Write<Error = E> + i2c::WriteRead<Error = E>,
-    {
+    pub fn set_maximum_angle(&mut self, bytes: u16) -> Result<(), Error<E>> {
         // 12-bit value.
-        self.write_u16(Register::Mang, bytes & 0x0FFF, i2c)
+        self.write_u16(Register::Mang, bytes & 0x0FFF)
     }
 
     /// Get value of register `CONF` and parse it.
-    pub fn config<I2c, E>(&mut self, i2c: &mut I2c) -> Result<Configuration, Error<E>>
-    where
-        I2c: i2c::Read<Error = E> + i2c::Write<Error = E> + i2c::WriteRead<Error = E>,
-    {
-        let bytes = self.read_u16(Register::Conf, i2c)?;
+    pub fn config(&mut self) -> Result<Configuration, Error<E>> {
+        let bytes = self.read_u16(Register::Conf)?;
         configuration::Configuration::try_from(bytes).map_err(Error::Configuration)
     }
 
     /// Set value of register `CONF`.
-    pub fn set_config<I2c, E>(
-        &mut self,
-        config: Configuration,
-        i2c: &mut I2c,
-    ) -> Result<(), Error<E>>
-    where
-        I2c: i2c::Read<Error = E> + i2c::Write<Error = E> + i2c::WriteRead<Error = E>,
-    {
+    pub fn set_config(&mut self, config: Configuration) -> Result<(), Error<E>> {
         // See note in datasheet about "blank fields may contain factory settings" on page 18.
-        let current_config = self.read_u16(Register::Conf, i2c)?;
+        let current_config = self.read_u16(Register::Conf)?;
         let blank_fields = current_config & 0b1100_0000_0000_0000;
         let mut bytes = u16::from(config);
         bytes |= blank_fields;
-        self.write_u16(Register::Conf, bytes, i2c)
+        self.write_u16(Register::Conf, bytes)
     }
 
     /// Get value of register `AGC`.
     /// This value differs depending on the supply voltage (5V or 3v3), see datasheet.
-    pub fn automatic_gain_control<I2c, E>(&mut self, i2c: &mut I2c) -> Result<u8, Error<E>>
-    where
-        I2c: i2c::Read<Error = E> + i2c::Write<Error = E> + i2c::WriteRead<Error = E>,
-    {
+    pub fn automatic_gain_control(&mut self) -> Result<u8, Error<E>> {
         let mut buffer = [0u8; 1];
-        i2c.write_read(self.address, &[0x1a], &mut buffer)?;
+        self.bus.write_read(self.address, &[0x1a], &mut buffer)?;
         Ok(buffer[0])
     }
 
     /// Get value of register `MAGNITUDE`.
-    pub fn magnitude<I2c, E>(&mut self, i2c: &mut I2c) -> Result<u16, Error<E>>
-    where
-        I2c: i2c::Read<Error = E> + i2c::Write<Error = E> + i2c::WriteRead<Error = E>,
-    {
+    pub fn magnitude(&mut self) -> Result<u16, Error<E>> {
         // 12-bit value.
-        Ok(self.read_u16(Register::Magnitude, i2c)? & 0x0FFF)
+        Ok(self.read_u16(Register::Magnitude)? & 0x0FFF)
     }
 
     /// Burn maximum angle and config register.
     /// Only proceeds if position settings (MPOS and ZPOS) have never been persisted before.
     /// See datasheet for constraints.
-    pub fn persist_maximum_angle_and_config_settings<I2c, D, E>(
+    pub fn persist_maximum_angle_and_config_settings<D>(
         &mut self,
-        i2c: &mut I2c,
         delay: &mut D,
     ) -> Result<(), Error<E>>
     where
-        I2c: i2c::Read<Error = E> + i2c::Write<Error = E> + i2c::WriteRead<Error = E>,
         D: DelayMs<u32>,
     {
-        let zmco = self.zmco(i2c)?;
+        let zmco = self.zmco()?;
         if zmco != 0 {
             return Err(Error::MangConfigPersistenceExhausted);
         }
-        i2c.write(self.address, &[Register::Burn.into(), 0x40])?;
+        self.bus
+            .write(self.address, &[Register::Burn.into(), 0x40])?;
         delay.delay_ms(1);
         Ok(())
     }
 
     /// Burn zero position and maximum to As5600 memory, if ZMCO permits it and a magnet is detected.
     /// See datasheet for constraints.
-    pub fn persist_position_settings<I2c, D, E>(
-        &mut self,
-        i2c: &mut I2c,
-        delay: &mut D,
-    ) -> Result<(), Error<E>>
+    pub fn persist_position_settings<D>(&mut self, delay: &mut D) -> Result<(), Error<E>>
     where
-        I2c: i2c::Read<Error = E> + i2c::Write<Error = E> + i2c::WriteRead<Error = E>,
         D: DelayMs<u32>,
     {
-        let zmco = self.zmco(i2c)?;
+        let zmco = self.zmco()?;
         if zmco >= 3 {
             return Err(Error::MaximumPositionPersistsReached);
         }
-        if self.magnet_status(i2c)? != Status::MagnetDetected {
+        if self.magnet_status()? != Status::MagnetDetected {
             return Err(Error::MagnetRequired);
         }
-        i2c.write(self.address, &[Register::Burn.into(), 0x80])
+        self.bus
+            .write(self.address, &[Register::Burn.into(), 0x80])
             .map_err(Error::Communication)?;
         delay.delay_ms(1);
         Ok(())
     }
 
     /// Helper function for write-reading 2 bytes from the given register.
-    fn read_u16<I2c, E>(&mut self, command: Register, i2c: &mut I2c) -> Result<u16, Error<E>>
-    where
-        I2c: i2c::Read<Error = E> + i2c::Write<Error = E> + i2c::WriteRead<Error = E>,
-    {
+    fn read_u16(&mut self, command: Register) -> Result<u16, Error<E>> {
         let mut buffer = [0u8; 2];
-        i2c.write_read(self.address, &[command.into()], &mut buffer)?;
+        self.bus
+            .write_read(self.address, &[command.into()], &mut buffer)?;
         Ok(u16::from_be_bytes(buffer))
     }
 
     /// Helper function for writing 2 bytes to the given register.
-    fn write_u16<I2c, E>(
-        &mut self,
-        command: Register,
-        bytes: u16,
-        i2c: &mut I2c,
-    ) -> Result<(), Error<E>>
-    where
-        I2c: i2c::Read<Error = E> + i2c::Write<Error = E> + i2c::WriteRead<Error = E>,
-    {
+    fn write_u16(&mut self, command: Register, bytes: u16) -> Result<(), Error<E>> {
         let bytes: [u8; 2] = bytes.to_be_bytes();
         let buffer = [u8::from(command), bytes[0], bytes[1]];
-        Ok(i2c.write(self.address, &buffer)?)
+        Ok(self.bus.write(self.address, &buffer)?)
     }
 }


### PR DESCRIPTION
Just FYI - the reason that `i2c` is not a member of the `As5600` struct is that an I2C bus is usually shared between several drivers. This means that it should not be owned by any driver. Just so you know why this design was chosen (I can see in this PR that you are choosing to change the driver to own the peripheral, which is fine, it just probably won't make it to my main branch :) )