### PR TITLE
Add optional support for the AS5600L sensor variant

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/barafael/as5600-rs"
 documentation = "https://docs.rs/crate/as5600/latest"
 
 [features]
+as5600l = []
 async = ["dep:embedded-hal-async"]
 defmt = ["dep:defmt"]
 
@@ -18,8 +19,8 @@ proptest = "1"
 proptest-derive = "0.4"
 
 [dependencies]
+defmt = { version = "1", optional = true }
 embedded-hal = "1"
 embedded-hal-async = { version = "1", optional = true }
 num-derive = "0.4"
 num-traits = { version = "0.2", default-features = false }
-defmt = { version = "1", optional = true }

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,4 +22,8 @@ pub enum Error<E> {
 
     /// No more persistent writes available for maximum angle and configuration registers.
     MangConfigPersistenceExhausted,
+
+    /// Invalid I2C address for AS5600L. Address must be between 8 and 119.
+    #[cfg(feature = "as5600l")]
+    InvalidAddress,
 }

--- a/src/register/mod.rs
+++ b/src/register/mod.rs
@@ -28,6 +28,12 @@ pub enum Register {
     Agc = 0x1A,
     /// This value holds the measured magnitude of the applied magnetic field.
     Magnitude = 0x1B,
+    #[cfg(feature = "as5600l")]
+    /// I2C address register (AS5600L only).
+    I2CAddress = 0x20,
+    #[cfg(feature = "as5600l")]
+    /// I2C update register (AS5600L only).
+    I2CUPDT = 0x21,
     Burn = 0xFF,
 }
 
@@ -52,6 +58,10 @@ impl TryFrom<u8> for Register {
             0x1A => Ok(Self::Agc),
             0x1B => Ok(Self::Magnitude),
             0xFF => Ok(Self::Burn),
+            #[cfg(feature = "as5600l")]
+            0x20 => Ok(Self::I2CAddress),
+            #[cfg(feature = "as5600l")]
+            0x21 => Ok(Self::I2CUPDT),
             _ => Err(error::Error::Register(byte)),
         }
     }


### PR DESCRIPTION
The [AS5600L](https://ams-osram.com/products/sensor-solutions/position-sensors/ams-as5600l-magnetic-rotary-position-sensor) sensor is nearly identical to the AS5600, with the main difference being that it features a programmable I2C address. This PR adds an optional `as5600l` feature to support setting the address and burning it permanently.